### PR TITLE
feat(src): options of gulp.src can be set via config

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,8 @@ Config.build = {
 };
 
 Config.server = {
-  filePattern: ['server/**/!(*.spec).{jade,js}', 'package.json']
+  filePattern: ['server/**/!(*.spec).{jade,js}', 'package.json'],
+  copySrcOptions: {}
 };
 ```
 

--- a/config.js
+++ b/config.js
@@ -9,6 +9,7 @@ Config.server = {
   path: 'server/',
   runnable: Config.build.distPath + 'processes/web/index.js',
   filePattern: ['!server/**/*.factory.*', '!server/**/*.spec.*', 'server/**/*.{jade,js,css,json}',  'package.json', 'trace.config.js', 'Procfile'],
+  copySrcOptions: {},
   watchPattern: 'server/**/*.js',
   environmentVariables: {
     NODE_ENV: process.env.NODE_ENV || 'development',

--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -5,7 +5,7 @@ module.exports = function(gulp, config) {
     var gulpif = require('gulp-if');
     var changed = require('gulp-changed');
 
-    return gulp.src(config.server.filePattern)
+    return gulp.src(config.server.filePattern, config.server.copySrcOptions)
       .pipe(gulpif(onlyChanged, changed(config.build.distPath)))
       .pipe(gulp.dest(config.build.distPath));
   };


### PR DESCRIPTION
Hey @Valetudox we just added options for gulp.src so server.copy got a bit smarter, we can pass options now. Default for the options is an empty object.
