### PR TITLE
Override default environment variables with process environment variables

### DIFF
--- a/config.js
+++ b/config.js
@@ -11,11 +11,11 @@ Config.server = {
   filePattern: ['!server/**/*.factory.*', '!server/**/*.spec.*', 'server/**/*.{jade,js,css,json}',  'package.json', 'trace.config.js', 'Procfile'],
   watchPattern: 'server/**/*.js',
   environmentVariables: {
-    NODE_ENV: process.env.NODE_ENV || 'development',
+    NODE_ENV: 'development',
     APP_ROOT_PATH: process.cwd() + '/' + Config.build.distPath + '/processes/web/',
-    IP: process.env.IP || undefined,
-    PORT: process.env.PORT || 9100,
-    BASE_URL: process.env.BASE_URL || 'http://localhost:9100'
+    IP: undefined,
+    PORT: 9100,
+    BASE_URL: 'http://localhost:9100'
   },
   test: {
     requires: ['co-mocha'],

--- a/tasks/start.js
+++ b/tasks/start.js
@@ -2,16 +2,18 @@
 
 module.exports = function(gulp, config) {
   return function() {
+    var _ = require('lodash');
     var nodemon = require('gulp-nodemon');
     var notifier = require('node-notifier');
     var path = require('path');
+    var env = _.extend({}, config.server.environmentVariables, process.env);
 
     nodemon({
       script: config.server.runnable,
       ext: 'js jade',
       watch: [config.build.distPath],
       delay: 1,
-      env: config.server.environmentVariables,
+      env: env,
       nodeArgs: ['--harmony']
     }).on('restart', function() {
       notifier.notify({


### PR DESCRIPTION
With this we do not have to explicitly override default environment variables one-by-one in tasks.config.
Also this will happen in runtime, allowing to use dotenv for running scripts
