### PR TITLE
fix(start): do not use harmony flag when starting the server

### DIFF
--- a/tasks/start.js
+++ b/tasks/start.js
@@ -13,8 +13,7 @@ module.exports = function(gulp, config) {
       ext: 'js jade',
       watch: [config.build.distPath],
       delay: 1,
-      env: env,
-      nodeArgs: ['--harmony']
+      env: env
     }).on('restart', function() {
       notifier.notify({
         title: 'Boar tasks',


### PR DESCRIPTION
BREAKING CHANGE: to use ES6 in the server script (i.e.: boar-server),
you should use a Node version that support it without harmony flag.
