### PR TITLE
Mocha hangs up after running tests

### DIFF
--- a/config.js
+++ b/config.js
@@ -17,7 +17,7 @@ module.exports = {
     },
     test: {
       requires: ['co-mocha'],
-      flags: ['reporter dot', 'colors'],
+      flags: ['reporter dot', 'colors', 'exit'],
       filePatterns: ['server/**/*.spec.js'],
       environmentVariables: {
         NODE_ENV: process.env.NODE_ENV || 'test',


### PR DESCRIPTION
Mocha v4 changes automatic process killing after running test and requires passing `--exit` flag to behave like in pre-v4 versions.
Without the flag, it hangs up the process.